### PR TITLE
Added support to Hotmart Videos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,9 @@ python-dotenv = "^0.15.0"
 youtube-dl = "^2020.12.2"
 pathvalidate = "^2.3.0"
 selenium = "3.141.0"
+selenium-wire = "2.1.2"
 webdriver_manager = "3.2.2"
+pycryptodome = "3.9.9"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.7"
 python-dotenv = "^0.15.0"
 youtube-dl = "^2020.12.2"
 pathvalidate = "^2.3.0"
+selenium = "3.141.0"
+webdriver_manager = "3.2.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"

--- a/src/hotmart_bot/__main__.py
+++ b/src/hotmart_bot/__main__.py
@@ -2,23 +2,11 @@ import argparse
 import os
 from re import S
 
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options as ChromeOptions
-from selenium.webdriver.chrome.webdriver import WebDriver
-from webdriver_manager.chrome import ChromeDriverManager
 
 from hotmart_bot.bot.hotmart_bot import HotmartBot
 from hotmart_bot.video_download.download_manager import DownloadManager
 
 
-def create_webdriver() -> WebDriver:
-    options = ChromeOptions()
-    options.add_argument("--start-maximized")
-    driver = webdriver.Chrome(ChromeDriverManager().install(), options=options)
-    driver.set_page_load_timeout(60 * 5)
-    driver.implicitly_wait(10)
-
-    return driver
 
 def create_parser() -> argparse.ArgumentParser:
     hotmart_parser = argparse.ArgumentParser(description="Download a course in Hotmart")
@@ -47,23 +35,23 @@ def main():
         USERNAME = args.username
         PWD = args.password
 
-    driver = create_webdriver()
-    hb = HotmartBot(driver)
+    hb = HotmartBot()
 
     hb.login(SITE, USERNAME, PWD)
     modules = hb.get_modules_list()
     download_manager = DownloadManager(len(modules))
 
     for module in modules:
-        module.lessons = hb.get_lessons_list(module)
         if args.output_path:
             module.create_folder(args.output_path)
         else:
             module.create_folder()
 
-        for lesson in module.lessons:
-            lesson.create_folder(module)
-            download_manager.new_thread(lesson.videos, lesson.path, SITE).start()
+        module.lessons = hb.get_lessons_list(module)
+        
+        # for lesson in module.lessons:
+        #     lesson.create_folder(module)
+        #     download_manager.new_thread(lesson.videos, lesson.path, SITE).start()
 
 
 if __name__ == "__main__":

--- a/src/hotmart_bot/bot/hotmart_bot.py
+++ b/src/hotmart_bot/bot/hotmart_bot.py
@@ -1,29 +1,65 @@
+import json
+import re
 import time
+
+from http.cookies import SimpleCookie
+
 from typing import List
 
-from selenium import webdriver
+from seleniumwire import webdriver
+
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.chrome.webdriver import WebDriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.keys import Keys
 
+from webdriver_manager.chrome import ChromeDriverManager
+
 from hotmart_bot.models.course import Lesson, Module, Video
-from hotmart_bot.video_download.download_manager import DownloadManager
+from hotmart_bot.video_download.video_downloader import VideoDownloader
+
+
+request_history = []
+
+def callback_requests(req, req_body, res, res_body):
+    request_history.append((req, res))
 
 
 class HotmartBot(object):
-    def __init__(self, driver: WebDriver) -> None:
-        self._driver = driver
+    def __init__(self) -> None:
+        self._create_webdriver()
 
-    def _extract_video_urls(self) -> List[Video]:
+
+    def _create_webdriver(self):
+        options = ChromeOptions()
+        options.add_argument("--start-maximized")
+
+        capabilities = DesiredCapabilities.CHROME
+        capabilities["goog:loggingPrefs"] = {"performance": "ALL"}
+
+        soptions = {
+            'custom_response_handler': callback_requests
+        }
+
+        self._driver = webdriver.Chrome(ChromeDriverManager().install(), options=options, desired_capabilities=capabilities, seleniumwire_options=soptions)
+        self._driver.set_page_load_timeout(60 * 5)
+        self._driver.implicitly_wait(10)
+
+
+    def _extract_video_urls(self):
         videos = []
         iframes = self._driver.find_elements_by_tag_name("iframe")
         for iframe in iframes:
             src = iframe.get_attribute("src")
             if "youtube" in src:
-                videos.append(Video("youtube", src))
+                yield Video("youtube", src)
             elif "vimeo" in src:
-                videos.append(Video("vimeo", src))
-        return videos
+                yield Video("vimeo", src)
+            elif "player.hotmart" in src:
+                src = self.discover_url()
+                cookies = self.get_cookies(src)
+                yield Video("hotmart", src, cookies)
+
 
     def login(self, domain: str, username: str, pwd: str) -> None:
         URL = "".join(["https://", domain, ".club.hotmart.com"])
@@ -36,6 +72,7 @@ class HotmartBot(object):
         password.clear()
         password.send_keys(pwd)
         password.send_keys(Keys.RETURN)
+
 
     def get_modules_list(self) -> List[Module]:
         modules = []
@@ -51,11 +88,13 @@ class HotmartBot(object):
             modules.append(course_module)
         return modules
 
+
     def get_lessons_list(self, module: Module) -> List[Lesson]:
-        lessons = []
+        
         lessons_elements = module.element.find_element_by_class_name(
             "navigation-module-pages"
         ).find_elements_by_class_name("navigation-page")
+        
         for lesson_element in lessons_elements:
 
             lesson_element.find_element_by_class_name(
@@ -63,14 +102,93 @@ class HotmartBot(object):
             ).find_element_by_class_name("navigation-page-title")
             lesson_element.click()
             time.sleep(2)
-            videos = self._extract_video_urls()
+
             lesson = Lesson(
                 lesson_element.text,
                 lesson_element,
                 [],
                 self._driver.current_url,
-                videos,
+                [],
             )
-            lessons.append(lesson)
 
-        return lessons
+            lesson.create_folder(module)
+
+            for video in self._extract_video_urls():
+                VideoDownloader.download_video(video, lesson.path, 'https://player.hotmart.com/')
+
+    @staticmethod
+    def filter_request(request):
+        video_regex = re.compile('^https://player.hotmart.com/embed/[^/]+/source/[^/]+=\\.m3u8$')
+
+        try:
+            url = request[0].path
+            return video_regex.match(url)
+        except KeyError:
+            return False
+
+        return False
+
+    @staticmethod
+    def filter_token(request):
+        video_regex = re.compile('^https://player.hotmart.com/embed/[^/]+?token=.*$')
+
+        try:
+            url = request[0].path
+            return video_regex.match(url)
+        except KeyError:
+            return False
+
+        return False
+
+    def discover_url(self):
+
+        video_requests = list(filter(HotmartBot.filter_request, request_history))
+
+        if len(video_requests) > 0:
+            return video_requests[-1][0].path
+
+        return None
+
+    def get_cookies(self, video_url):
+        video_id_regex = re.compile('^https://player.hotmart.com/embed/([^/]+)/source/[^/]+=\\.m3u8$')
+        video_id = ''
+
+        match = video_id_regex.match(video_url)
+        if match:
+            video_id = match.group(1)
+
+        video_requests = list(filter(lambda x:x[0].path == video_url, request_history))
+
+        cookies = ''
+
+        if len(video_requests) > 0:
+            headers = video_requests[-1][0].headers
+            cookies = headers.get('Cookie')
+
+        token_requests = list(filter(HotmartBot.filter_token, request_history))
+
+        if len(token_requests) == 0:
+            return cookies
+            
+        video_cookies = []
+
+        for request in token_requests:
+            simple_cookie = SimpleCookie()
+            
+            headers = request[1].headers
+            raw_cookies = headers.get_all('Set-Cookie')
+        
+            for c in raw_cookies:
+                simple_cookie.load(c)
+
+            for entry in simple_cookie.keys():
+                path = simple_cookie[entry]['path']
+                if video_id in path:
+                    video_cookies.append(entry + '=' + simple_cookie[entry].coded_value)
+
+        if len(video_cookies) > 0:
+            video_cookies = list(set(video_cookies))
+            cookies = cookies.strip().strip(';')
+            cookies = cookies + '; ' + "; ".join(video_cookies)
+
+        return cookies

--- a/src/hotmart_bot/downloader/hotmart.py
+++ b/src/hotmart_bot/downloader/hotmart.py
@@ -1,0 +1,208 @@
+from __future__ import unicode_literals
+
+import re
+import binascii
+import base64
+
+try:
+    from Crypto.Cipher import AES
+    can_decrypt_frag = True
+except ImportError:
+    can_decrypt_frag = False
+
+from youtube_dl.downloader.fragment import FragmentFD
+from youtube_dl.downloader.external import FFmpegFD
+
+from youtube_dl.compat import (
+    compat_urllib_error,
+    compat_urlparse,
+    compat_struct_pack,
+)
+from youtube_dl.utils import (
+    parse_m3u8_attributes,
+    update_url_query,
+)
+
+
+class HotmartFD(FragmentFD):
+    """ A limited implementation that does not require ffmpeg """
+
+    FD_NAME = 'hlsnative_hotmart'
+
+    @staticmethod
+    def can_download(manifest, info_dict=dict()):
+        return True
+
+    def real_download(self, filename, info_dict):
+        man_url = info_dict['url']
+        self.to_screen('[%s] Downloading m3u8 manifest' % self.FD_NAME)
+
+        urlh = self.ydl.urlopen(self._prepare_url(info_dict, man_url))
+        man_url = urlh.geturl()
+        s = urlh.read().decode('utf-8', 'ignore')
+
+        if not self.can_download(s, info_dict):
+            if info_dict.get('extra_param_to_segment_url') or info_dict.get('_decryption_key_url'):
+                self.report_error('pycrypto not found. Please install it.')
+                return False
+            self.report_warning(
+                'hlsnative has detected features it does not support, '
+                'extraction will be delegated to ffmpeg')
+            fd = FFmpegFD(self.ydl, self.params)
+            for ph in self._progress_hooks:
+                fd.add_progress_hook(ph)
+            return fd.real_download(filename, info_dict)
+
+        def is_ad_fragment_start(s):
+            return (s.startswith('#ANVATO-SEGMENT-INFO') and 'type=ad' in s
+                    or s.startswith('#UPLYNK-SEGMENT') and s.endswith(',ad'))
+
+        def is_ad_fragment_end(s):
+            return (s.startswith('#ANVATO-SEGMENT-INFO') and 'type=master' in s
+                    or s.startswith('#UPLYNK-SEGMENT') and s.endswith(',segment'))
+
+        media_frags = 0
+        ad_frags = 0
+        ad_frag_next = False
+        for line in s.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith('#'):
+                if is_ad_fragment_start(line):
+                    ad_frag_next = True
+                elif is_ad_fragment_end(line):
+                    ad_frag_next = False
+                continue
+            if ad_frag_next:
+                ad_frags += 1
+                continue
+            media_frags += 1
+
+        ctx = {
+            'filename': filename,
+            'total_frags': media_frags,
+            'ad_frags': ad_frags,
+        }
+
+        self._prepare_and_start_frag_download(ctx)
+
+        fragment_retries = self.params.get('fragment_retries', 5)
+        skip_unavailable_fragments = self.params.get('skip_unavailable_fragments', True)
+        test = self.params.get('test', False)
+
+        extra_query = None
+        extra_param_to_segment_url = info_dict.get('extra_param_to_segment_url')
+        if extra_param_to_segment_url:
+            extra_query = compat_urlparse.parse_qs(extra_param_to_segment_url)
+        i = 0
+        media_sequence = 0
+        decrypt_info = {'METHOD': 'NONE'}
+        byte_range = {}
+        frag_index = 0
+        ad_frag_next = False
+        for line in s.splitlines():
+            line = line.strip()
+            if line:
+                if not line.startswith('#'):
+                    if ad_frag_next:
+                        continue
+                    frag_index += 1
+                    if frag_index <= ctx['fragment_index']:
+                        continue
+                    frag_url = (
+                        line
+                        if re.match(r'^https?://', line)
+                        else compat_urlparse.urljoin(man_url, line))
+                    if extra_query:
+                        frag_url = update_url_query(frag_url, extra_query)
+                    count = 0
+                    headers = info_dict.get('http_headers', {})
+                    if byte_range:
+                        headers['Range'] = 'bytes=%d-%d' % (byte_range['start'], byte_range['end'])
+                    while count <= fragment_retries:
+                        try:
+                            success, frag_content = self._download_fragment(
+                                ctx, frag_url, info_dict, headers)
+                            if not success:
+                                return False
+                            break
+                        except compat_urllib_error.HTTPError as err:
+                            # Unavailable (possibly temporary) fragments may be served.
+                            # First we try to retry then either skip or abort.
+                            # See https://github.com/ytdl-org/youtube-dl/issues/10165,
+                            # https://github.com/ytdl-org/youtube-dl/issues/10448).
+                            self.to_screen('[%s] Error - %s - %s' % (self.FD_NAME, err.reason, headers))
+                            count += 1
+                            if count <= fragment_retries:
+                                self.report_retry_fragment(err, frag_index, count, fragment_retries)
+                    if count > fragment_retries:
+                        if skip_unavailable_fragments:
+                            i += 1
+                            media_sequence += 1
+                            self.report_skip_fragment(frag_index)
+                            continue
+                        self.report_error(
+                            'giving up after %s fragment retries' % fragment_retries)
+                        return False
+                    if decrypt_info['METHOD'] == 'AES-128':
+                        iv = decrypt_info.get('IV') or compat_struct_pack('>8xq', media_sequence)
+                        decrypt_info['KEY'] = decrypt_info.get('KEY') or self.ydl.urlopen(
+                            self._prepare_url(info_dict, info_dict.get('_decryption_key_url') or decrypt_info['URI'])).read()
+                        frag_content = AES.new(
+                            decrypt_info['KEY'], AES.MODE_CBC, iv).decrypt(frag_content)
+                    self._append_fragment(ctx, frag_content)
+                    # We only download the first fragment during the test
+                    if test:
+                        break
+                    i += 1
+                    media_sequence += 1
+                elif line.startswith('#EXT-X-KEY'):
+                    decrypt_url = decrypt_info.get('URI')
+                    decrypt_info = parse_m3u8_attributes(line[11:])
+                    if decrypt_info['METHOD'] == 'AES-128':
+                        if 'IV' in decrypt_info:
+                            decrypt_info['IV'] = binascii.unhexlify(decrypt_info['IV'][2:].zfill(32))
+                        if decrypt_info['URI'].startswith('chave://'):
+                            encrypted_url = decrypt_info['URI'].replace('chave://', '')
+                            encrypted_url = binascii.a2b_base64(encrypted_url)
+
+                            key = '49bded6736cb71dee90a0ddc3552f7483b20a20630b8d05541628d89f2691fb4'
+                            iv  = '49bded6736cb71dee90a0ddc3552f748'
+
+                            key = binascii.a2b_hex(key)
+                            iv  = binascii.a2b_hex(iv)
+
+                            aes = AES.new(key, AES.MODE_CBC, iv)
+                            decrypted_url = aes.decrypt(encrypted_url)
+                            
+                            decrypt_info['URI'] = decrypted_url.decode().strip()
+                        elif not re.match(r'^https?://', decrypt_info['URI']):
+                            self.to_screen('[%s] Strange key - %s' % (self.FD_NAME, decrypt_info['URI']))
+                            decrypt_info['URI'] = compat_urlparse.urljoin(
+                                man_url, decrypt_info['URI'])
+
+                            self.to_screen('[%s] Strange key - %s' % (self.FD_NAME, decrypt_info['URI']))
+                        if extra_query:
+                            decrypt_info['URI'] = update_url_query(decrypt_info['URI'], extra_query)
+                        if decrypt_url is not None and decrypt_url != decrypt_info['URI']:
+                            self.to_screen('[%s] Strange key - %s - %s' % (self.FD_NAME, decrypt_url, decrypt_info['URI']))
+                            decrypt_info['KEY'] = None
+                elif line.startswith('#EXT-X-MEDIA-SEQUENCE'):
+                    media_sequence = int(line[22:])
+                elif line.startswith('#EXT-X-BYTERANGE'):
+                    splitted_byte_range = line[17:].split('@')
+                    sub_range_start = int(splitted_byte_range[1]) if len(splitted_byte_range) == 2 else byte_range['end']
+                    byte_range = {
+                        'start': sub_range_start,
+                        'end': sub_range_start + int(splitted_byte_range[0]),
+                    }
+                elif is_ad_fragment_start(line):
+                    ad_frag_next = True
+                elif is_ad_fragment_end(line):
+                    ad_frag_next = False
+
+        self._finish_frag_download(ctx)
+
+        return True
+

--- a/src/hotmart_bot/models/course/video.py
+++ b/src/hotmart_bot/models/course/video.py
@@ -4,3 +4,4 @@ from dataclasses import dataclass
 class Video:
     source: str
     url: str
+    cookies: str

--- a/src/hotmart_bot/video_download/download_thread.py
+++ b/src/hotmart_bot/video_download/download_thread.py
@@ -33,7 +33,7 @@ class DownloadThread(Thread):
                 if retry == 5:
                     done = True
                 try:
-                    VideoDownloader.download_video(video.url, self.folder, self._referer)
+                    VideoDownloader.download_video(video, self.folder, self._referer)
                     done = True
                 except:
                     retry = retry + 1

--- a/src/hotmart_bot/video_download/video_downloader.py
+++ b/src/hotmart_bot/video_download/video_downloader.py
@@ -1,18 +1,45 @@
 import os
 
 import youtube_dl
+import youtube_dl.downloader.external
 
+from hotmart_bot.models.course import Video
+from hotmart_bot.downloader.hotmart import HotmartFD
+
+DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"
+
+
+# inject the new downloader in YTDL lib
+youtube_dl.downloader.external._BY_NAME['hotmart'] = HotmartFD
 
 class VideoDownloader(object):
     @staticmethod
-    def download_video(url: str, folder: str, referer: str):
-        print("URL: ", url)
+    def download_video(video: Video, folder: str, referer: str):
+        print("URL: ", video.url)
         youtube_dl.utils.std_headers["Referer"] = referer
+        
+        if video.cookies:
+            youtube_dl.utils.std_headers['Cookie'] = video.cookies
+
         ydl_opts = {
             "outtmpl": os.path.join(folder, "%(title)s.%(ext)s"),
             "quiet": True,
+            "verbose": False,
             "format": "best",
+            "fragment_retries": 10,
+            "http_headers": {
+                'Origin': referer,
+                'Referer': referer,
+                'Cookie': video.cookies
+            }
         }
 
+        # we need some headers to bypass CloudFront checker
+        if video.source == 'hotmart':
+            youtube_dl.utils.std_headers['User-Agent'] = DEFAULT_USER_AGENT
+            ydl_opts['external_downloader'] = 'hotmart'
+
+        
+        
         with youtube_dl.YoutubeDL(ydl_opts) as ydl:
-            ydl.download([url])
+            ydl.download([video.url])


### PR DESCRIPTION
This PR adds support to download hotmart videos. The code is ugly but works... sometimes.

To download a native video hosted on hotmart, you need 2 things. 

1. First, you need to get the URL containing the playlist and key. They implemented a variant of m3u8 format, in this variant, the key is a URL encoded with AES, using a key and an IV (the key and IV can be found in the player JS file). So, to resolve this, you need to download the m3u8 file, parse, find a line starting with `chave://` and decrypt using the key and iv found. The result will be the URL used to decrypt the video content.
2. Second, you need some cookies to download the fragments (a video is composed by many fragments, `*.ts*`). Looks like the videos are hosted in Amazon CloudFront, and these cookies are the keys to permit the download of these objects.  To capture these cookies, I used a proxy with selenium (selenium-wire), and logged all requests and responses. For some reason, these cookies didn't appear with `driver.get_cookies()`. Maybe because these cookies had a specific path, matching the video paths.

Well, with the correct key URL and the correct cookies, you will be able to download the native videos. Sadly, the code is very ugly in comparison with @mpupo wrote. Other problem is, sometimes the code don't work, maybe the cookies are messed up, I don't know, but when will download the `.ts*`, CloudFront returns a 403 - Forbidden error. When this happens, I simply run the code again and everything works.

Another problem with this approach is the cookies change if the code continues to navigate in the site, so, when the code finds the video, it needs to download after that or the cookies will be invalidated. So, the actual thread schema don't work, we need to download the videos in serial. I modified the code to download everything in serial, but maybe YouTube and Vimeo videos can enter a different path, using the actual code and only if exists native videos, we download in serial.
